### PR TITLE
(Fix) Close opened resources

### DIFF
--- a/usbdrivedetector_darwin.go
+++ b/usbdrivedetector_darwin.go
@@ -33,10 +33,11 @@ func Detect() ([]string, error) {
 	}
 
 	for k := range driveMap {
-		_, err := os.Open(k)
+		file, err := os.Open(k)
 		if err == nil {
 			drives = append(drives, k)
 		}
+		file.Close()
 	}
 
 	return drives, nil

--- a/usbdrivedetector_linux.go
+++ b/usbdrivedetector_linux.go
@@ -38,10 +38,11 @@ func Detect() ([]string, error) {
 	}
 
 	for k := range driveMap {
-		_, err := os.Open(k)
+		file, err := os.Open(k)
 		if err == nil {
 			drives = append(drives, k)
 		}
+		file.Close()
 	}
 
 	return drives, nil

--- a/usbdrivedetector_windows.go
+++ b/usbdrivedetector_windows.go
@@ -33,10 +33,11 @@ func Detect() ([]string, error) {
 	}
 
 	for k := range driveMap {
-		_, err := os.Open(k)
+		file, err := os.Open(k)
 		if err == nil {
 			drives = append(drives, k)
 		}
+		file.Close()
 	}
 
 	return drives, nil


### PR DESCRIPTION
I was getting a `target is busy` error when trying to unmount detected devices. This pull request solves the bug by closing the opned resources. 